### PR TITLE
Fix 404 on folders path

### DIFF
--- a/lib/help_scout/folder.rb
+++ b/lib/help_scout/folder.rb
@@ -8,7 +8,7 @@ module HelpScout
       private
 
       def base_path
-        'mailboxes/%<MAILBOX_ID>/folders/'
+        'mailboxes/%<MAILBOX_ID>/folders'
       end
 
       def list_path(mailbox_id)


### PR DESCRIPTION
Dash is throwing this 404 error when checking the [On Call: Ops](https://secure.helpscout.net/mailbox/2605770dc4ace57e/1310607/) folder

```
/u/apps/dash/shared/bundle/ruby/3.0.0/gems/help_scout-sdk-2.0.0/lib/help_scout/api.rb:42:in `handle_response': Resource Not Found (HelpScout::API::NotFound)
	from /u/apps/dash/shared/bundle/ruby/3.0.0/gems/help_scout-sdk-2.0.0/lib/help_scout/api.rb:61:in `send_request'
	from /u/apps/dash/shared/bundle/ruby/3.0.0/gems/help_scout-sdk-2.0.0/lib/help_scout/api.rb:17:in `get'
	from /u/apps/dash/shared/bundle/ruby/3.0.0/gems/help_scout-sdk-2.0.0/lib/help_scout/modules/listable.rb:6:in `list'
	from /u/apps/dash/shared/bundle/ruby/3.0.0/gems/help_scout-sdk-2.0.0/lib/help_scout/mailbox.rb:34:in `folders'
	from /u/apps/dash/releases/20231005223042/lib/helpscout/queue.rb:6:in `get_total_messages_for_queue'
	from /u/apps/dash/current/script/monitoring/helpscout_queue.rb:16:in `block in <main>'
	from /u/apps/dash/current/script/monitoring/helpscout_queue.rb:15:in `each'
	from /u/apps/dash/current/script/monitoring/helpscout_queue.rb:15:in `<main>'
```

After inspecting the requests and responses, I found out that the `folders/` endpoint is wrong (was probably updated) and the correct one now is `folders`.

`{"id"=>34734, "name"=>"Basecamp Support", "slug"=>"redacted", "email"=>"support@basecamp.com", "createdAt"=>"2014-12-05T18:26:20Z", "updatedAt"=>"2023-10-10T18:45:39Z", "_links"=>{"self"=>{"href"=>"https://api.helpscout.net/v2/mailboxes/34734"}, "folders"=>{"href"=>"https://api.helpscout.net/v2/mailboxes/34734/folders"}, "fields"=>{"href"=>"https://api.helpscout.net/v2/mailboxes/34734/fields"}}} 200`